### PR TITLE
feat: Support Custom Application Actions in UI #7577

### DIFF
--- a/cmd/argocd/commands/app_actions.go
+++ b/cmd/argocd/commands/app_actions.go
@@ -83,7 +83,7 @@ func NewApplicationResourceActionsListCommand(clientOpts *argocdclient.ClientOpt
 				ResourceName: pointer.String(obj.GetName()),
 				Group:        pointer.String(gvk.Group),
 				Kind:         pointer.String(gvk.Kind),
-				Version:      pointer.String(gvk.GroupVersion().Version),
+				Version:      pointer.String(gvk.Version),
 			})
 			errors.CheckError(err)
 			for _, action := range availActionsForResource.Actions {
@@ -192,5 +192,28 @@ func getActionableResourcesForApplication(appIf applicationpkg.ApplicationServic
 		ApplicationName: appName,
 		AppNamespace:    appNs,
 	})
-	return resources.Items, err
+	if err != nil {
+		return resources.Items, err
+	}
+	app, err := appIf.Get(ctx, &applicationpkg.ApplicationQuery{
+		Name:         appName,
+		AppNamespace: appNs,
+	})
+	if err != nil {
+		return resources.Items, err
+	}
+	app.Kind = "Application"
+	app.APIVersion = "argoproj.io/v1alpha1"
+	appManifest, err := json.Marshal(app)
+	if err != nil {
+		return resources.Items, err
+	}
+	appGVK := app.GroupVersionKind()
+	return append(resources.Items, &v1alpha1.ResourceDiff{
+		Group:     appGVK.Group,
+		Kind:      appGVK.Kind,
+		Namespace: app.Namespace,
+		Name:      *appName,
+		LiveState: string(appManifest),
+	}), err
 }

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -1760,7 +1760,7 @@ func (s *Server) logResourceEvent(res *appv1.ResourceNode, ctx context.Context, 
 }
 
 func (s *Server) ListResourceActions(ctx context.Context, q *application.ApplicationResourceRequest) (*application.ResourceActionsListResponse, error) {
-	obj, err := s.getUnstructuredLiveResourceOrApp(ctx, rbacpolicy.ActionGet, q)
+	obj, _, _, _, err := s.getUnstructuredLiveResourceOrApp(ctx, rbacpolicy.ActionGet, q)
 	if err != nil {
 		return nil, err
 	}
@@ -1781,10 +1781,8 @@ func (s *Server) ListResourceActions(ctx context.Context, q *application.Applica
 	return &application.ResourceActionsListResponse{Actions: actionsPtr}, nil
 }
 
-func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, err error) {
+func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, res *appv1.ResourceNode, app *appv1.Application, config *rest.Config, err error) {
 	var (
-		app       *appv1.Application
-		config    *rest.Config
 		gvk       schema.GroupVersionKind
 		name      string
 		namespace string
@@ -1794,21 +1792,20 @@ func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacReque
 		namespace = s.appNamespaceOrDefault(q.GetAppNamespace())
 		app, err = s.appLister.Applications(namespace).Get(name)
 		if err != nil {
-			return nil, fmt.Errorf("error getting app by name: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting app by name: %w", err)
 		}
 		if err = s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacRequest, app.RBACName(s.ns)); err != nil {
-			return nil, err
+			return nil, nil, nil, nil, err
 		}
 		config, err = s.getApplicationClusterConfig(ctx, app)
 		if err != nil {
-			return nil, fmt.Errorf("error getting application cluster config: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting application cluster config: %w", err)
 		}
 		gvk = app.GroupVersionKind()
 	} else {
-		var res *appv1.ResourceNode
 		res, config, app, err = s.getAppLiveResource(ctx, rbacRequest, q)
 		if err != nil {
-			return nil, fmt.Errorf("error getting app live resource: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("error getting app live resource: %w", err)
 		}
 		gvk = res.GroupKindVersion()
 		name = res.Name
@@ -1816,7 +1813,7 @@ func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacReque
 	}
 	obj, err = s.kubectl.GetResource(ctx, config, gvk, name, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("error getting resource: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("error getting resource: %w", err)
 	}
 	return
 }
@@ -1852,13 +1849,9 @@ func (s *Server) RunResourceAction(ctx context.Context, q *application.ResourceA
 		Group:        q.Group,
 	}
 	actionRequest := fmt.Sprintf("%s/%s/%s/%s", rbacpolicy.ActionAction, q.GetGroup(), q.GetKind(), q.GetAction())
-	res, config, a, err := s.getAppLiveResource(ctx, actionRequest, resourceRequest)
+	liveObj, res, a, config, err := s.getUnstructuredLiveResourceOrApp(ctx, actionRequest, resourceRequest)
 	if err != nil {
-		return nil, fmt.Errorf("error getting app live resource: %w", err)
-	}
-	liveObj, err := s.kubectl.GetResource(ctx, config, res.GroupKindVersion(), res.Name, res.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("error getting resource: %w", err)
+		return nil, err
 	}
 
 	resourceOverrides, err := s.settingsMgr.GetResourceOverrides()
@@ -1929,8 +1922,12 @@ func (s *Server) RunResourceAction(ctx context.Context, q *application.ResourceA
 		}
 	}
 
-	s.logAppEvent(a, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s on resource %s/%s/%s", q.GetAction(), res.Group, res.Kind, res.Name))
-	s.logResourceEvent(res, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s", q.GetAction()))
+	if res == nil {
+		s.logAppEvent(a, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s", q.GetAction()))
+	} else {
+		s.logAppEvent(a, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s on resource %s/%s/%s", q.GetAction(), res.Group, res.Kind, res.Name))
+		s.logResourceEvent(res, ctx, argo.EventReasonResourceActionRan, fmt.Sprintf("ran action %s", q.GetAction()))
+	}
 	return &application.ApplicationResponse{}, nil
 }
 

--- a/server/application/application.go
+++ b/server/application/application.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
@@ -1759,13 +1760,9 @@ func (s *Server) logResourceEvent(res *appv1.ResourceNode, ctx context.Context, 
 }
 
 func (s *Server) ListResourceActions(ctx context.Context, q *application.ApplicationResourceRequest) (*application.ResourceActionsListResponse, error) {
-	res, config, _, err := s.getAppLiveResource(ctx, rbacpolicy.ActionGet, q)
+	obj, err := s.getUnstructuredLiveResourceOrApp(ctx, rbacpolicy.ActionGet, q)
 	if err != nil {
-		return nil, fmt.Errorf("error getting app live resource: %w", err)
-	}
-	obj, err := s.kubectl.GetResource(ctx, config, res.GroupKindVersion(), res.Name, res.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("error getting resource: %w", err)
+		return nil, err
 	}
 	resourceOverrides, err := s.settingsMgr.GetResourceOverrides()
 	if err != nil {
@@ -1782,6 +1779,46 @@ func (s *Server) ListResourceActions(ctx context.Context, q *application.Applica
 	}
 
 	return &application.ResourceActionsListResponse{Actions: actionsPtr}, nil
+}
+
+func (s *Server) getUnstructuredLiveResourceOrApp(ctx context.Context, rbacRequest string, q *application.ApplicationResourceRequest) (obj *unstructured.Unstructured, err error) {
+	var (
+		app       *appv1.Application
+		config    *rest.Config
+		gvk       schema.GroupVersionKind
+		name      string
+		namespace string
+	)
+	if q.GetKind() == "Application" && q.GetGroup() == "argoproj.io" && q.GetName() == q.GetResourceName() {
+		name = q.GetName()
+		namespace = s.appNamespaceOrDefault(q.GetAppNamespace())
+		app, err = s.appLister.Applications(namespace).Get(name)
+		if err != nil {
+			return nil, fmt.Errorf("error getting app by name: %w", err)
+		}
+		if err = s.enf.EnforceErr(ctx.Value("claims"), rbacpolicy.ResourceApplications, rbacRequest, app.RBACName(s.ns)); err != nil {
+			return nil, err
+		}
+		config, err = s.getApplicationClusterConfig(ctx, app)
+		if err != nil {
+			return nil, fmt.Errorf("error getting application cluster config: %w", err)
+		}
+		gvk = app.GroupVersionKind()
+	} else {
+		var res *appv1.ResourceNode
+		res, config, app, err = s.getAppLiveResource(ctx, rbacRequest, q)
+		if err != nil {
+			return nil, fmt.Errorf("error getting app live resource: %w", err)
+		}
+		gvk = res.GroupKindVersion()
+		name = res.Name
+		namespace = res.Namespace
+	}
+	obj, err = s.kubectl.GetResource(ctx, config, gvk, name, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("error getting resource: %w", err)
+	}
+	return
 }
 
 func (s *Server) getAvailableActions(resourceOverrides map[string]appv1.ResourceOverride, obj *unstructured.Unstructured) ([]appv1.ResourceAction, error) {

--- a/ui/src/app/applications/components/application-details/application-details.tsx
+++ b/ui/src/app/applications/components/application-details/application-details.tsx
@@ -614,6 +614,28 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
         const refreshing = app.metadata.annotations && app.metadata.annotations[appModels.AnnotationRefreshKey];
         const fullName = AppUtils.nodeKey({group: 'argoproj.io', kind: app.kind, name: app.metadata.name, namespace: app.metadata.namespace});
         const ActionMenuItem = (prop: {actionLabel: string}) => <span className={needOverlapLabelOnNarrowScreen ? 'show-for-large' : ''}>{prop.actionLabel}</span>;
+        const resourceActions = services.applications
+            .getApplicationActions(app.metadata.name, app.metadata.namespace)
+            .then(actions => {
+                return actions.map(action => ({
+                    title: action.name,
+                    disabled: !!action.disabled,
+                    action: async () => {
+                        try {
+                            const confirmed = await appContext.apis.popup.confirm(`Execute '${action.name}' action?`, `Are you sure you want to execute '${action.name}' action?`);
+                            if (confirmed) {
+                                await services.applications.runApplicationAction(app.metadata.name, app.metadata.namespace, action.name);
+                            }
+                        } catch (e) {
+                            appContext.apis.notifications.show({
+                                content: <ErrorNotification title='Unable to execute resource action' e={e} />,
+                                type: NotificationType.Error
+                            });
+                        }
+                    }
+                }));
+            })
+            .catch(() => items);
         return [
             {
                 iconClassName: 'fa fa-info-circle',
@@ -628,7 +650,16 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{app
             },
             {
                 iconClassName: 'fa fa-sync',
-                title: <ActionMenuItem actionLabel='Sync' />,
+                title: (resourceActions.length
+                    ? <React.Fragment>
+                        <ActionMenuItem actionLabel='Sync' />{' '}
+                        <DropDownMenu
+                            items={resourceActions}
+                            anchor={() => <i className='fa fa-caret-down' />}
+                        />
+                      </React.Fragment>
+                    : <ActionMenuItem actionLabel='Sync' />
+                ),
                 action: () => AppUtils.showDeploy('all', this.appContext)
             },
             {

--- a/ui/src/app/shared/services/applications-service.ts
+++ b/ui/src/app/shared/services/applications-service.ts
@@ -308,6 +308,33 @@ export class ApplicationsService {
             .then(res => (res.body.actions as models.ResourceAction[]) || []);
     }
 
+    public getApplicationActions(name: string, appNamspace: string): Promise<models.ResourceAction[]> {
+        return requests
+            .get(`/applications/${name}/resource/actions`)
+            .query({
+                namespace: appNamespace,
+                resourceName: name,
+                version: 'v1alpha1',
+                kind: 'Application',
+                group: 'argoproj.io'
+            })
+            .then(res => (res.body.actions as models.ResourceAction[]) || []);
+    }
+
+    public runApplicationAction(name: string, appNamspace: string, action: string): Promise<models.ResourceAction[]> {
+        return requests
+            .post(`/applications/${name}/resource/actions`)
+            .query({
+                namespace: appNamespace,
+                resourceName: name,
+                version: 'v1alpha1',
+                kind: 'Application',
+                group: 'argoproj.io'
+            })
+            .send(JSON.stringify(action))
+            .then(res => (res.body.actions as models.ResourceAction[]) || []);
+    }
+
     public patchResource(name: string, appNamspace: string, resource: models.ResourceNode, patch: string, patchType: string): Promise<models.State> {
         return requests
             .post(`/applications/${name}/resource`)


### PR DESCRIPTION
Prior to this change, custom resource actions targeting an Application
could be viewed and run from the CLI, but were not made available via
the UI.

This change adds any custom Application actions to a drop down menu on
the Sync button in all instances of the Application menu; if no such
actions exist the drop down UI element is omitted from the Sync button,
leaving the UI unchanged.

Closes #7577

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/7577) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [x] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

